### PR TITLE
Stop embedding Swift standard libraries

### DIFF
--- a/Shuffle.xcodeproj/project.pbxproj
+++ b/Shuffle.xcodeproj/project.pbxproj
@@ -1043,6 +1043,7 @@
 		AD72AC662270E5E20083E735 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -1069,6 +1070,7 @@
 		AD72AC672270E5E20083E735 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
When i want to use Shuffle in my project whose dependency manager is Carthage, Transporter Error is occurred.

```
[13:56:23]: [Transporter Error Output]: ERROR ITMS-90206: "Invalid Bundle. The bundle at 'MyProject.app/Frameworks/Shuffle.framework' contains disallowed file 'Frameworks'."
[13:56:23]: Transporter transfer failed.
[13:56:23]:
[13:56:23]: ERROR ITMS-90206: "Invalid Bundle. The bundle at 'MyProject.app/Frameworks/Shuffle.framework' contains disallowed file 'Frameworks'."
```

So I changed `Always Embed Swift Standard Libraries` option to `No`. Then problem solved!