### PR TITLE
bump to version 0.2.1

### DIFF
--- a/Shuffle-iOS.podspec
+++ b/Shuffle-iOS.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name         = "Shuffle-iOS"
-s.version      = "0.2.0"
+s.version      = "0.2.1"
 s.platform     = :ios, "9.0"
 s.summary      = "A multi-directional card swiping library inspired by Tinder"
 
@@ -13,7 +13,7 @@ s.homepage     = "https://github.com/mac-gallagher/Shuffle"
 s.documentation_url = "https://github.com/mac-gallagher/Shuffle/tree/master/README.md"
 s.license      = { :type => 'MIT', :file => 'LICENSE' }
 s.author       = { "Mac Gallagher" => "jmgallagher36@gmail.com" }
-s.source       = { :git => "https://github.com/mac-gallagher/Shuffle.git", :tag => "v0.2.0" }
+s.source       = { :git => "https://github.com/mac-gallagher/Shuffle.git", :tag => "v0.2.1" }
 
 s.swift_version = "5.0"
 s.source_files = "Sources/**/*.{h,swift}"


### PR DESCRIPTION
`pod spec lint` was unsuccessful for `0.2.0`