### PR TITLE
fix issue where non-animated swipe would still animate

### DIFF
--- a/Sources/Shuffle/SwipeCard/CardAnimator.swift
+++ b/Sources/Shuffle/SwipeCard/CardAnimator.swift
@@ -26,76 +26,99 @@
 import UIKit
 
 protocol CardAnimatable {
+
+  /// Calling this method triggers a spring-like animation on the card, eventually settling back to it's original position.
+  /// - Parameter card: The card to animate.
   func animateReset(on card: SwipeCard)
-  func animateReverseSwipe(on card: SwipeCard, from direction: SwipeDirection)
-  func animateSwipe(on card: SwipeCard, direction: SwipeDirection, forced: Bool)
+
+  /// Calling this method triggers a reverse swipe (i.e. undo) animation on the card.
+  /// - Parameters:
+  ///   - card: The card to animate.
+  ///   - direction: The direction from which the card will be coming off-screen.
+  ///   - completion: An optional block which is called once the animation has completed.
+  func animateReverseSwipe(on card: SwipeCard,
+                           from direction: SwipeDirection,
+                           completion: ((Bool) -> Void)?)
+
+  /// Calling this method triggers a swipe animation on the card.
+  /// - Parameters:
+  ///   - card: The card to animate.
+  ///   - direction: The direction to which the card will swipe off-screen.
+  ///   - forced: A boolean idicating whether the card was swiped programmatically
+  ///   - completion: An optional block which is called once the animation has completed.
+  func animateSwipe(on card: SwipeCard,
+                    direction: SwipeDirection,
+                    forced: Bool,
+                    completion: ((Bool) -> Void)?)
+
+  /// Calling this method will remove any active animations on the card and it's layers.
+  /// - Parameter card: The card on which the animations will be removed.
   func removeAllAnimations(on card: SwipeCard)
 }
 
 class CardAnimator: CardAnimatable {
-  
+
   static var shared = CardAnimator()
-  
+
   // MARK: - Main Methods
 
   func animateReset(on card: SwipeCard) {
     removeAllAnimations(on: card)
-    
+
     Animator.animateSpring(withDuration: card.animationOptions.totalResetDuration,
                            usingSpringWithDamping: card.animationOptions.resetSpringDamping,
                            options: [.curveLinear, .allowUserInteraction],
-                           animations: { 
+                           animations: {
                             if let direction = card.activeDirection(),
                               let overlay = card.overlay(forDirection: direction) {
                               overlay.alpha = 0
                             }
-                            card.transform = .identity
-    })
+                            card.transform = .identity })
   }
 
-  func animateReverseSwipe(on card: SwipeCard, from direction: SwipeDirection) {
+  func animateReverseSwipe(on card: SwipeCard,
+                           from direction: SwipeDirection,
+                           completion: ((Bool) -> Void)?) {
     removeAllAnimations(on: card)
 
     // recreate swipe
     Animator.animateKeyFrames(withDuration: 0.0,
                               animations: { [weak self] in
-                                self?.addSwipeAnimationKeyFrames(card, direction: direction, forced: true)
-    })
+                                self?.addSwipeAnimationKeyFrames(card,
+                                                                 direction: direction,
+                                                                 forced: true)} )
 
     // reverse swipe
     Animator.animateKeyFrames(withDuration: card.animationOptions.totalReverseSwipeDuration,
                               options: .calculationModeLinear,
                               animations: { [weak self] in
-                                self?.addReverseSwipeAnimationKeyFrames(card, direction: direction)
-    }) { finished in
-      if finished {
-        card.reverseSwipeCompletionBlock()
-      }
-    }
+                                self?.addReverseSwipeAnimationKeyFrames(card, direction: direction)},
+                              completion: completion)
   }
 
-  func animateSwipe(on card: SwipeCard, direction: SwipeDirection, forced: Bool) {
+  func animateSwipe(on card: SwipeCard,
+                    direction: SwipeDirection,
+                    forced: Bool,
+                    completion: ((Bool) -> Void)?) {
     removeAllAnimations(on: card)
 
     let duration = swipeDuration(card, direction: direction, forced: forced)
     Animator.animateKeyFrames(withDuration: duration,
                               options: .calculationModeLinear,
                               animations: { [weak self] in
-                                self?.addSwipeAnimationKeyFrames(card, direction: direction, forced: forced)
-    }) { finished in
-      if finished {
-        card.swipeCompletionBlock()
-      }
-    }
+                                self?.addSwipeAnimationKeyFrames(card,
+                                                                 direction: direction,
+                                                                 forced: forced) },
+                              completion: completion)
   }
-  
+
   func removeAllAnimations(on card: SwipeCard) {
     card.layer.removeAllAnimations()
-    for direction in card.swipeDirections {
-      card.overlay(forDirection: direction)?.layer.removeAllAnimations()
+    card.swipeDirections.forEach {
+      card.overlay(forDirection: $0)?.layer.removeAllAnimations()
     }
   }
-  
+
   // MARK: - Animation Keyframes
 
   func addReverseSwipeAnimationKeyFrames(_ card: SwipeCard, direction: SwipeDirection) {
@@ -119,10 +142,12 @@ class CardAnimator: CardAnimatable {
   }
 
   func addSwipeAnimationKeyFrames(_ card: SwipeCard, direction: SwipeDirection, forced: Bool) {
-    let relativeOverlayDuration = relativeSwipeOverlayFadeDuration(card, direction: direction, forced: forced)
+    let relativeOverlayDuration = relativeSwipeOverlayFadeDuration(card,
+                                                                   direction: direction,
+                                                                   forced: forced)
 
     // overlays
-    for swipeDirection in card.swipeDirections.filter({$0 != direction}) {
+    for swipeDirection in card.swipeDirections.filter({ $0 != direction }) {
       card.overlay(forDirection: swipeDirection)?.alpha = 0.0
     }
 
@@ -138,10 +163,11 @@ class CardAnimator: CardAnimatable {
                                   relativeDuration: 1 - relativeOverlayDuration,
                                   transform: transform)
   }
-  
+
   // MARK: - Animation Calculations
 
-  func relativeReverseSwipeOverlayFadeDuration(_ card: SwipeCard, direction: SwipeDirection) -> Double {
+  func relativeReverseSwipeOverlayFadeDuration(_ card: SwipeCard,
+                                               direction: SwipeDirection) -> Double {
     let overlay = card.overlay(forDirection: direction)
     if overlay != nil {
       return card.animationOptions.relativeReverseSwipeOverlayFadeDuration
@@ -149,7 +175,9 @@ class CardAnimator: CardAnimatable {
     return 0.0
   }
 
-  func relativeSwipeOverlayFadeDuration(_ card: SwipeCard, direction: SwipeDirection, forced: Bool) -> Double {
+  func relativeSwipeOverlayFadeDuration(_ card: SwipeCard,
+                                        direction: SwipeDirection,
+                                        forced: Bool) -> Double {
     let overlay = card.overlay(forDirection: direction)
     if forced && overlay != nil {
       return card.animationOptions.relativeSwipeOverlayFadeDuration
@@ -161,14 +189,14 @@ class CardAnimator: CardAnimatable {
     if forced {
       return card.animationOptions.totalSwipeDuration
     }
-    
+
     let velocityFactor = card.dragSpeed(on: direction) / card.minimumSwipeSpeed(on: direction)
-    
+
     // card swiped below the minimum swipe speed
     if velocityFactor < 1.0 {
       return card.animationOptions.totalSwipeDuration
     }
-    
+
     // card swiped at least the minimum swipe speed -> return relative duration
     return 1.0 / TimeInterval(velocityFactor)
   }
@@ -203,7 +231,7 @@ class CardAnimator: CardAnimatable {
     return CGAffineTransform(rotationAngle: swipeRotationAngle(card, direction: direction, forced: forced))
       .concatenating(CGAffineTransform(translationX: actualTranslation.x, y: actualTranslation.y))
   }
-  
+
   func swipeTranslation(_ card: SwipeCard, direction: SwipeDirection, directionVector: CGVector) -> CGVector {
     let cardDiagonalLength = CGVector(card.bounds.size).length
     let maxScreenLength = max(UIScreen.main.bounds.width, UIScreen.main.bounds.height)

--- a/Sources/Shuffle/SwipeCard/SwipeCard.swift
+++ b/Sources/Shuffle/SwipeCard/SwipeCard.swift
@@ -132,9 +132,7 @@ open class SwipeCard: SwipeView {
   private func layoutOverlays() {
     overlayContainer.frame = layoutProvider.createOverlayContainerFrame(for: self)
     bringSubviewToFront(overlayContainer)
-    for overlay in overlays.values {
-      overlay.frame = overlayContainer.bounds
-    }
+    overlays.values.forEach { $0.frame = overlayContainer.bounds }
   }
 
   // MARK: - Overrides
@@ -166,7 +164,8 @@ open class SwipeCard: SwipeView {
   override open func didSwipe(_ recognizer: UIPanGestureRecognizer,
                               with direction: SwipeDirection) {
     super.didSwipe(recognizer, with: direction)
-    swipeAction(direction: direction, forced: false, animated: true)
+    delegate?.card(didSwipe: self, with: direction)
+    swipeAction(direction: direction, forced: false)
   }
 
   override open func didCancelSwipe(_ recognizer: UIPanGestureRecognizer) {
@@ -218,27 +217,33 @@ open class SwipeCard: SwipeView {
     return overlays[direction]
   }
 
-  public func swipe(direction: SwipeDirection, animated: Bool) {
-    swipeAction(direction: direction, forced: true, animated: animated)
+  /// Calling this method triggers a swipe animation.
+  /// - Parameter direction: The direction to which the card will swipe off-screen.
+  public func swipe(direction: SwipeDirection) {
+    swipeAction(direction: direction, forced: true)
   }
 
-  func swipeAction(direction: SwipeDirection, forced: Bool, animated: Bool) {
+  func swipeAction(direction: SwipeDirection, forced: Bool) {
     isUserInteractionEnabled = false
-    delegate?.card(didSwipe: self, with: direction, forced: forced)
-    if animated {
-      animator.animateSwipe(on: self, direction: direction, forced: forced)
-    } else {
-      swipeCompletionBlock()
+    animator.animateSwipe(on: self,
+                          direction: direction,
+                          forced: forced)
+    { [weak self] finished in
+      if finished {
+        self?.swipeCompletionBlock()
+      }
     }
   }
 
-  public func reverseSwipe(from direction: SwipeDirection, animated: Bool) {
+  /// Calling this method triggers a reverse swipe (undo) animation.
+  /// - Parameter direction: The direction from which the card will be coming off-screen.
+  public func reverseSwipe(from direction: SwipeDirection) {
     isUserInteractionEnabled = false
-    delegate?.card(didReverseSwipe: self, from: direction)
-    if animated {
-      animator.animateReverseSwipe(on: self, from: direction)
-    } else {
-      reverseSwipeCompletionBlock()
+    animator.animateReverseSwipe(on: self, from: direction)
+    { [weak self] finished in
+      if finished {
+        self?.reverseSwipeCompletionBlock()
+      }
     }
   }
 

--- a/Sources/Shuffle/SwipeCard/SwipeCardDelegate.swift
+++ b/Sources/Shuffle/SwipeCard/SwipeCardDelegate.swift
@@ -29,8 +29,7 @@ protocol SwipeCardDelegate: class {
   func card(didBeginSwipe card: SwipeCard)
   func card(didCancelSwipe card: SwipeCard)
   func card(didContinueSwipe card: SwipeCard)
-  func card(didReverseSwipe card: SwipeCard, from direction: SwipeDirection)
-  func card(didSwipe card: SwipeCard, with direction: SwipeDirection, forced: Bool)
+  func card(didSwipe card: SwipeCard, with direction: SwipeDirection)
   func card(didTap card: SwipeCard)
 
   func shouldRecognizeHorizontalDrag(on card: SwipeCard) -> Bool?

--- a/Tests/ShuffleTests/SwipeCard/Mocks/MockCardAnimator.swift
+++ b/Tests/ShuffleTests/SwipeCard/Mocks/MockCardAnimator.swift
@@ -36,19 +36,21 @@ class MockCardAnimator: CardAnimatable {
   var animateReverseSwipeCalled: Bool = false
   var animateReverseSwipeDirection: SwipeDirection?
 
-  func animateReverseSwipe(on card: SwipeCard, from direction: SwipeDirection) {
+  func animateReverseSwipe(on card: SwipeCard, from direction: SwipeDirection, completion: ((Bool) -> Void)?) {
     animateReverseSwipeCalled = true
     animateReverseSwipeDirection = direction
+    completion?(true)
   }
 
   var animateSwipeCalled: Bool = false
   var animateSwipeDirection: SwipeDirection?
   var animateSwipeForced: Bool?
 
-  func animateSwipe(on card: SwipeCard, direction: SwipeDirection, forced: Bool) {
+  func animateSwipe(on card: SwipeCard, direction: SwipeDirection, forced: Bool, completion: ((Bool) -> Void)?) {
     animateSwipeCalled = true
     animateSwipeDirection = direction
     animateSwipeForced = forced
+    completion?(true)
   }
 
   var removeAllAnimationsCalled: Bool = false

--- a/Tests/ShuffleTests/SwipeCard/Mocks/MockSwipeCardDelegate.swift
+++ b/Tests/ShuffleTests/SwipeCard/Mocks/MockSwipeCardDelegate.swift
@@ -43,22 +43,12 @@ class MockSwipeCardDelegate: SwipeCardDelegate {
     didContinueSwipeCalled = true
   }
 
-  var didReverseSwipeCalled: Bool = false
-  var didReverseSwipeDirection: SwipeDirection?
-
-  func card(didReverseSwipe card: SwipeCard, from direction: SwipeDirection) {
-    didReverseSwipeCalled = true
-    didReverseSwipeDirection = direction
-  }
-
   var didSwipeCalled: Bool = false
   var didSwipeDirection: SwipeDirection?
-  var didSwipeForced: Bool?
 
-  func card(didSwipe card: SwipeCard, with direction: SwipeDirection, forced: Bool) {
+  func card(didSwipe card: SwipeCard, with direction: SwipeDirection) {
     didSwipeCalled = true
     didSwipeDirection = direction
-    didSwipeForced = forced
   }
 
   var didTapCalled: Bool = false

--- a/Tests/ShuffleTests/SwipeCard/Specs/CardAnimatorSpec.swift
+++ b/Tests/ShuffleTests/SwipeCard/Specs/CardAnimatorSpec.swift
@@ -46,10 +46,6 @@ class CardAnimatorSpec: QuickSpec {
       card.frame = CGRect(x: 0, y: 0, width: cardWidth, height: cardHeight)
     }
 
-    afterEach {
-      UIView.setAnimationsEnabled(true)
-    }
-
     //MARK: - Main Methods
 
     //MARK: Animate Reset
@@ -58,8 +54,6 @@ class CardAnimatorSpec: QuickSpec {
       let overlay = UIView()
 
       beforeEach {
-        UIView.setAnimationsEnabled(false)
-
         card.transform = CGAffineTransform(a: 1, b: 2, c: 3, d: 4, tx: 5, ty: 6)
         card.testActiveDirection = .left
         card.setOverlay(overlay, forDirection: .left)
@@ -83,10 +77,14 @@ class CardAnimatorSpec: QuickSpec {
     describe("When calling animateReverseSwipe") {
       let overlay = UIView()
 
+      var completionCalled: Bool = false
+      let testCompletion: (Bool) -> Void = { _ in
+        completionCalled = true
+      }
+
       beforeEach {
-        UIView.setAnimationsEnabled(false)
         card.setOverlay(overlay, forDirection: .left)
-        subject.animateReverseSwipe(on: card, from: .left)
+        subject.animateReverseSwipe(on: card, from: .left, completion: testCompletion)
       }
 
       it("should remove all animations on the card") {
@@ -101,17 +99,27 @@ class CardAnimatorSpec: QuickSpec {
         expect(subject.addReverseSwipeAnimationKeyFramesCalled).to(beTrue())
       }
 
-      it("should call the card's reverse swipe completion block once the animation has completed") {
-        expect(card.reverseSwipeCompletionBlockCalled).toEventually(beTrue())
+      it("should call the completion block once the animation has completed") {
+        expect(completionCalled).toEventually(beTrue())
       }
     }
 
     // MARK: Animate Swipe
 
     describe("When calling animateSwipe") {
+      let direction = SwipeDirection.left
+      let forced: Bool = false
+
+      var completionCalled: Bool = false
+      let testCompletion: (Bool) -> Void = { _ in
+        completionCalled = true
+      }
+
       beforeEach {
-        UIView.setAnimationsEnabled(false)
-        subject.animateSwipe(on: card, direction: .left, forced: false)
+        subject.animateSwipe(on: card,
+                             direction: direction,
+                             forced: forced,
+                             completion: testCompletion)
       }
 
       it("should remove all animations on the card") {
@@ -122,8 +130,8 @@ class CardAnimatorSpec: QuickSpec {
         expect(subject.addSwipeAnimationKeyFramesCalled).to(beTrue())
       }
 
-      it("should call the card's swipe completion block once the animation has completed") {
-        expect(card.swipeCompletionBlockCalled).toEventually(beTrue())
+      it("should call completion block once the animation has completed") {
+        expect(completionCalled).toEventually(beTrue())
       }
     }
 

--- a/Tests/ShuffleTests/SwipeCard/Specs/SwipeCardSpec_Base.swift
+++ b/Tests/ShuffleTests/SwipeCard/Specs/SwipeCardSpec_Base.swift
@@ -334,10 +334,14 @@ class SwipeCardSpec_Base: QuickSpec {
         subject.didSwipe(UIPanGestureRecognizer(), with: direction)
       }
 
+      it ("should call the delegate's didSwipe method") {
+        expect(mockSwipeCardDelegate.didSwipeCalled).to(beTrue())
+      }
+
       it("should call the swipeAction method with the correct parameters") {
+        expect(subject.swipeActionCalled).to(beTrue())
         expect(subject.swipeActionDirection).to(equal(direction))
         expect(subject.swipeActionForced).to(equal(false))
-        expect(subject.swipeActionAnimated).to(equal(true))
       }
     }
 
@@ -388,18 +392,18 @@ class SwipeCardSpec_Base: QuickSpec {
                                               translation: nil,
                                               velocity: CGPoint(x: 0, y: 1))
         }
-        
+
         it("should return the value from the delegate") {
           let actualResult = subject.gestureRecognizerShouldBegin(testPanGestureRecognizer)
           expect(actualResult).to(equal(recognizeVerticalDrag))
         }
       }
-      
+
       context("and the delegate is nil or the shouldDrag method has not been implemented") {
         beforeEach {
           subject.delegate = nil
         }
-        
+
         it("should return the value from the superclass") {
           let actualResult = subject.gestureRecognizerShouldBegin(testPanGestureRecognizer)
           expect(actualResult).to(beTrue())

--- a/Tests/ShuffleTests/SwipeCard/Specs/SwipeCardSpec_MainMethods.swift
+++ b/Tests/ShuffleTests/SwipeCard/Specs/SwipeCardSpec_MainMethods.swift
@@ -112,16 +112,15 @@ class SwipeCardSpec_MainMethods: QuickSpec {
 
     describe("When calling swipe") {
       let direction: SwipeDirection = .left
-      let animated: Bool = false
 
       beforeEach {
-        subject.swipe(direction: direction, animated: animated)
+        subject.swipe(direction: direction)
       }
 
       it("should call the swipeAction method with the correct parameters") {
+        expect(subject.swipeActionCalled).to(beTrue())
         expect(subject.swipeActionDirection).to(equal(direction))
         expect(subject.swipeActionForced).to(equal(true))
-        expect(subject.swipeActionAnimated).to(equal(animated))
       }
     }
 
@@ -131,54 +130,26 @@ class SwipeCardSpec_MainMethods: QuickSpec {
       let direction: SwipeDirection = .left
       let forced: Bool = false
 
-      context("and animated is true") {
-        beforeEach {
-          subject.swipeAction(direction: direction,
-                              forced: forced,
-                              animated: true)
-        }
-
-        it("should disable the user interaction on the card") {
-          expect(subject.isUserInteractionEnabled).to(beFalse())
-        }
-
-        it("should call the didSwipe delegate method with the correct parameters") {
-          expect(mockSwipeCardDelegate.didSwipeCalled).to(beTrue())
-          expect(mockSwipeCardDelegate.didSwipeDirection).to(equal(direction))
-          expect(mockSwipeCardDelegate.didSwipeForced).to(equal(forced))
-        }
-
-        it("call the animator's swipe method with the correct parameters") {
-          expect(mockCardAnimator.animateSwipeCalled).to(beTrue())
-          expect(mockCardAnimator.animateSwipeDirection).to(equal(direction))
-          expect(mockCardAnimator.animateSwipeForced).to(equal(forced))
-        }
+      beforeEach {
+        subject.swipeAction(direction: direction, forced: forced)
       }
 
-      context("and animated is false") {
-        beforeEach {
-          subject.swipeAction(direction: direction,
-                              forced: forced,
-                              animated: false)
-        }
+      it("should disable the user interaction on the card") {
+        expect(subject.isUserInteractionEnabled).to(beFalse())
+      }
 
-        it("should disable the user interaction on the card") {
-          expect(subject.isUserInteractionEnabled).to(beFalse())
-        }
+      it("should not call the didSwipe delegate method") {
+        expect(mockSwipeCardDelegate.didSwipeCalled).to(beFalse())
+      }
 
-        it("should call the didSwipe delegate method with the correct parameters") {
-          expect(mockSwipeCardDelegate.didSwipeCalled).to(beTrue())
-          expect(mockSwipeCardDelegate.didSwipeDirection).to(equal(direction))
-          expect(mockSwipeCardDelegate.didSwipeForced).to(equal(forced))
-        }
+      it("should call the animator's swipe method with the correct parameters") {
+        expect(mockCardAnimator.animateSwipeCalled).to(beTrue())
+        expect(mockCardAnimator.animateSwipeDirection).to(equal(direction))
+        expect(mockCardAnimator.animateSwipeForced).to(equal(forced))
+      }
 
-        it("should call the card's swipe completion block") {
-          expect(subject.swipeCompletionBlockCalled).to(beTrue())
-        }
-
-        it("should not call the animator's swipe") {
-          expect(mockCardAnimator.animateSwipeCalled).to(beFalse())
-        }
+      it("should invoke the swipe completion block once the animation has completed") {
+        expect(subject.swipeCompletionBlockCalled).to(beTrue())
       }
     }
 
@@ -187,43 +158,22 @@ class SwipeCardSpec_MainMethods: QuickSpec {
     describe("When calling reverseSwipe") {
       let direction: SwipeDirection = .left
 
-      context("and animated is true") {
-        beforeEach {
-          subject.reverseSwipe(from: direction, animated: true)
-        }
-
-        it("should disable user interaction on the card") {
-          expect(subject.isUserInteractionEnabled).to(beFalse())
-        }
-
-        it("should call the reverseSwipe delegate method with the correct parameters") {
-          expect(mockSwipeCardDelegate.didReverseSwipeCalled).to(beTrue())
-          expect(mockSwipeCardDelegate.didReverseSwipeDirection).to(equal(direction))
-        }
-
-        it("should call the animator's reverse swipe method with the correct direction") {
-          expect(mockCardAnimator.animateReverseSwipeCalled).to(beTrue())
-          expect(mockCardAnimator.animateReverseSwipeDirection).to(equal(direction))
-        }
+      beforeEach {
+        subject.testReverseSwipeCompletionBlock = {}
+        subject.reverseSwipe(from: direction)
       }
 
-      context("and animated is false") {
-        beforeEach {
-          subject.reverseSwipe(from: direction, animated: false)
-        }
+      it("should disable user interaction on the card") {
+        expect(subject.isUserInteractionEnabled).to(beFalse())
+      }
 
-        it("should call the reverseSwipe delegate method with the correct parameters") {
-          expect(mockSwipeCardDelegate.didReverseSwipeCalled).to(beTrue())
-          expect(mockSwipeCardDelegate.didReverseSwipeDirection).to(equal(direction))
-        }
+      it("should call the animator's reverse swipe method with the correct direction") {
+        expect(mockCardAnimator.animateReverseSwipeCalled).to(beTrue())
+        expect(mockCardAnimator.animateReverseSwipeDirection).to(equal(direction))
+      }
 
-        it("should not call the animator's reverse swipe method") {
-          expect(mockCardAnimator.animateReverseSwipeCalled).to(beFalse())
-        }
-
-        it("should call the card's reverse swipe completion block") {
-          expect(subject.reverseSwipeCompletionBlockCalled).to(beTrue())
-        }
+      it("should invoke the reverse swipe completion block once the animation has completed") {
+        expect(subject.reverseSwipeCompletionBlockCalled).to(beTrue())
       }
     }
 
@@ -231,7 +181,6 @@ class SwipeCardSpec_MainMethods: QuickSpec {
 
     describe("When calling removeAllAnimations") {
       beforeEach {
-
         // add animation key to card
         UIView.animate(withDuration: 100, animations: {
           subject.alpha = 0

--- a/Tests/ShuffleTests/SwipeCard/Testables/TestableSwipeCard.swift
+++ b/Tests/ShuffleTests/SwipeCard/Testables/TestableSwipeCard.swift
@@ -42,9 +42,11 @@ class TestableSwipeCard: SwipeCard {
   }
 
   var reverseSwipeCompletionBlockCalled: Bool = false
+  var testReverseSwipeCompletionBlock: (() -> Void)?
+
   override var reverseSwipeCompletionBlock: () -> Void {
     reverseSwipeCompletionBlockCalled = true
-    return super.reverseSwipeCompletionBlock
+    return testReverseSwipeCompletionBlock ?? super.reverseSwipeCompletionBlock
   }
 
   // MARK: - Swipe Calculations
@@ -77,53 +79,47 @@ class TestableSwipeCard: SwipeCard {
 
   // MARK: - Main Methods
 
-  var setOverlayCalled: Bool = false
   var setOverlayOverlays = [SwipeDirection: UIView]()
 
   override func setOverlay(_ overlay: UIView?, forDirection direction: SwipeDirection) {
-    super.setOverlay(overlay, forDirection: direction)
     setOverlayOverlays[direction] = overlay
-    setOverlayCalled = true
+    super.setOverlay(overlay, forDirection: direction)
   }
 
+  var swipeActionCalled: Bool = false
   var swipeActionDirection: SwipeDirection?
   var swipeActionForced: Bool?
-  var swipeActionAnimated: Bool?
 
-  override func swipeAction(direction: SwipeDirection, forced: Bool, animated: Bool) {
-    super.swipeAction(direction: direction, forced: forced, animated: animated)
+  override func swipeAction(direction: SwipeDirection, forced: Bool) {
+    swipeActionCalled = true
     swipeActionDirection = direction
     swipeActionForced = forced
-    swipeActionAnimated = animated
+    super.swipeAction(direction: direction, forced: forced)
   }
 
   var swipeCalled: Bool = false
   var swipeDirection: SwipeDirection?
-  var swipeAnimated: Bool?
 
-  override func swipe(direction: SwipeDirection, animated: Bool) {
-    super.swipe(direction: direction, animated: animated)
+  override func swipe(direction: SwipeDirection) {
     swipeCalled = true
     swipeDirection = direction
-    swipeAnimated = animated
+    super.swipe(direction: direction)
   }
 
   var reverseSwipeCalled: Bool = false
   var reverseSwipeDirection: SwipeDirection?
-  var reverseSwipeAnimated: Bool?
 
-  override func reverseSwipe(from direction: SwipeDirection, animated: Bool) {
-    super.reverseSwipe(from: direction, animated: animated)
+  override func reverseSwipe(from direction: SwipeDirection) {
     reverseSwipeCalled = true
     reverseSwipeDirection = direction
-    reverseSwipeAnimated = animated
+    super.reverseSwipe(from: direction)
   }
 
   // MARK: - Lifecycle
 
   var setNeedsLayoutCalled: Bool = false
   override func setNeedsLayout() {
-    super.setNeedsLayout()
     setNeedsLayoutCalled = true
+    super.setNeedsLayout()
   }
 }

--- a/Tests/ShuffleTests/SwipeCardStack/Mocks/MockCardStackAnimator.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Mocks/MockCardStackAnimator.swift
@@ -29,36 +29,57 @@ import UIKit
 class MockCardStackAnimator: CardStackAnimatable {
 
   var animateResetCalled: Bool = false
-  func animateReset(_ cardStack: SwipeCardStack, topCard: SwipeCard) {
+  func animateReset(_ cardStack: SwipeCardStack,
+                    topCard: SwipeCard) {
     animateResetCalled = true
   }
 
   var animateShiftCalled: Bool = false
   var animateShiftDistance: Int?
+  var animateShiftAnimated: Bool?
 
-  func animateShift(_ cardStack: SwipeCardStack, withDistance distance: Int) {
+  func animateShift(_ cardStack: SwipeCardStack,
+                    withDistance distance: Int,
+                    animated: Bool,
+                    completion: ((Bool) -> Void)?) {
     animateShiftCalled = true
     animateShiftDistance = distance
+    animateShiftAnimated = animated
+    completion?(true)
   }
 
   var animateSwipeCalled: Bool = false
-  var animateSwipeForced: Bool?
-  var animateSwipeDirection: SwipeDirection?
   var animateSwipeTopCard: SwipeCard?
+  var animateSwipeDirection: SwipeDirection?
+  var animateSwipeForced: Bool?
+  var animateSwipeAnimated: Bool?
 
   func animateSwipe(_ cardStack: SwipeCardStack,
                     topCard: SwipeCard,
                     direction: SwipeDirection,
-                    forced: Bool) {
+                    forced: Bool,
+                    animated: Bool,
+                    completion: ((Bool) -> Void)?) {
     animateSwipeCalled = true
-    animateSwipeForced = forced
-    animateSwipeDirection = direction
     animateSwipeTopCard = topCard
+    animateSwipeDirection = direction
+    animateSwipeForced = forced
+    animateSwipeAnimated = animated
+    completion?(true)
   }
 
   var animateUndoCalled: Bool = false
-  func animateUndo(_ cardStack: SwipeCardStack, topCard: SwipeCard) {
+  var animateUndoTopCard: SwipeCard?
+  var animateUndoAnimated: Bool?
+
+  func animateUndo(_ cardStack: SwipeCardStack,
+                   topCard: SwipeCard,
+                   animated: Bool,
+                   completion: ((Bool) -> Void)?) {
+    animateUndoTopCard = topCard
+    animateUndoAnimated = animated
     animateUndoCalled = true
+    completion?(true)
   }
 
   var removeBackgroundCardAnimationsCalled: Bool = false

--- a/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_Base.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_Base.swift
@@ -258,7 +258,7 @@ class SwipeCardStackSpec_Base: QuickSpec {
       }
     }
 
-    // MARK: Undo Completion
+    // MARK: Undo Completion Block
 
     describe("When the undo completion block is called") {
       beforeEach {
@@ -271,7 +271,7 @@ class SwipeCardStackSpec_Base: QuickSpec {
       }
     }
 
-    // MARK: Shift Completion
+    // MARK: Shift Completion Block
 
     describe("When the shift completion block is called") {
       beforeEach {
@@ -389,7 +389,7 @@ class SwipeCardStackSpec_Base: QuickSpec {
         subject.testScaleFactor = scaleFactor
       }
 
-      it("should return the identity transform") {
+      it("should return the correct scaled transform") {
         let actualTransform = subject.transform(forCardAtIndex: 0)
         let expectedTransform = CGAffineTransform(scaleX: scaleFactor.x,
                                                   y: scaleFactor.y)

--- a/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_SwipeCardDelegate.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_SwipeCardDelegate.swift
@@ -100,33 +100,13 @@ class SwipeCardStackSpec_SwipeCardDelegate: QuickSpec {
       beforeEach {
         backgroundCards = [SwipeCard(), SwipeCard(), SwipeCard()]
         subject.testBackgroundCards = backgroundCards
+        mockTransformProvider.testBackgroundCardDragTransform = cardTransform
+        subject.card(didContinueSwipe: SwipeCard())
       }
 
-      context("and there is no topCard") {
-        beforeEach {
-          subject.testTopCard = nil
-          mockTransformProvider.testBackgroundCardDragTransform = cardTransform
-          subject.card(didContinueSwipe: SwipeCard())
-        }
-
-        it("should not set the transforms on any of the background cards") {
-          for card in backgroundCards {
-            expect(card.transform).toNot(equal(cardTransform))
-          }
-        }
-      }
-
-      context("and there is a top card") {
-        beforeEach {
-          subject.testTopCard = SwipeCard()
-          mockTransformProvider.testBackgroundCardDragTransform = cardTransform
-          subject.card(didContinueSwipe: SwipeCard())
-        }
-
-        it("should set the transforms on any of the background cards") {
-          for card in backgroundCards {
-            expect(card.transform).to(equal(cardTransform))
-          }
+      it("should set the transforms on any of the background cards") {
+        for card in backgroundCards {
+          expect(card.transform).to(equal(cardTransform))
         }
       }
     }
@@ -147,135 +127,16 @@ class SwipeCardStackSpec_SwipeCardDelegate: QuickSpec {
 
     context("When calling didSwipe") {
       let direction: SwipeDirection = .left
-      let forced: Bool = false
-      let topCard = SwipeCard()
 
-      context("and topIndex is nil") {
-        beforeEach {
-          subject.testTopCardIndex = nil
-          subject.visibleCards = [topCard]
-          subject.card(didSwipe: SwipeCard(), with: .left, forced: true)
-        }
-
-        it("it should not call the didSwipeCardAtDelegate method") {
-          expect(mockDelegate.didSwipeCardAtCalled).to(beFalse())
-        }
-      }
-
-      context("and topIndex is not nil") {
-        let index: Int = 2
-
-        beforeEach {
-          subject.testTopCardIndex = index
-          subject.visibleCards = [topCard]
-          subject.card(didSwipe: topCard, with: direction, forced: forced)
-        }
-
-        it("should call the didSwipeCardAt delegate method with the correct parameters") {
-          expect(mockDelegate.didSwipeCardAtCalled).to(beTrue())
-          expect(mockDelegate.didSwipeCardAtIndex).to(equal(index))
-          expect(mockDelegate.didSwipeCardAtDirection).to(equal(direction))
-        }
-      }
-
-      context("and there is at least one more card to load") {
-        let testLoadCard = SwipeCard()
-        let numberOfVisibleCards: Int = 2
-        let remainingIndices = [0, 1, 2]
-
-        beforeEach {
-          mockStateManager.remainingIndices = remainingIndices
-          subject.visibleCards = [topCard, SwipeCard()]
-          subject.testLoadCard = testLoadCard
-          subject.card(didSwipe: topCard, with: direction, forced: forced)
-        }
-
-        testSwipe()
-
-        it("should not call the didSwipeAllCards delegate method") {
-          expect(mockDelegate.didSwipeAllCardsCalled).to(beFalse())
-        }
-
-        it("should load the card from the correct data source index") {
-          expect(subject.loadCardCalled).to(beTrue())
-          expect(subject.loadCardCalledIndex).to(equal(remainingIndices[numberOfVisibleCards - 1]))
-        }
-
-        it("should insert the loaded card at the correct index in the card stack") {
-          expect(subject.insertCardCalled).to(beTrue())
-          expect(subject.insertCardCard).to(equal(testLoadCard))
-          expect(subject.insertCardIndex).to(equal(numberOfVisibleCards - 1))
-        }
-      }
-
-      context("and there are no more cards to load") {
-        beforeEach {
-          mockStateManager.remainingIndices = [1, 2]
-          subject.visibleCards = [topCard, SwipeCard(), SwipeCard()]
-          subject.card(didSwipe: topCard, with: direction, forced: forced)
-        }
-
-        testSwipe()
-
-        it("should not call the didSwipeAllCards delegate method") {
-          expect(mockDelegate.didSwipeAllCardsCalled).to(beFalse())
-        }
-
-        it("not load a new card") {
-          expect(subject.loadCardCalled).to(beFalse())
-        }
-      }
-
-      context("and there are no more cards to swipe") {
-        beforeEach {
-          mockStateManager.remainingIndices = []
-          subject.visibleCards = [topCard]
-          subject.card(didSwipe: topCard, with: direction, forced: forced)
-        }
-
-        testSwipe()
-
-        it("should call the didSwipeAllCards delegate method") {
-          expect(mockDelegate.didSwipeAllCardsCalled).to(beTrue())
-        }
-      }
-
-      func testSwipe() {
-        it("should call the state manager's swipe method with the correct direction") {
-          expect(mockStateManager.swipeCalled).to(beTrue())
-          expect(mockStateManager.swipeDirection).to(equal(direction))
-        }
-
-        it("should remove the top card from visibleCards") {
-          expect(subject.visibleCards.contains(topCard)).to(beFalse())
-        }
-
-        it("should disable user interaction") {
-          expect(subject.isUserInteractionEnabled).to(beFalse())
-        }
-
-        it("should call the animator's swipe method with the correct parameters") {
-          expect(mockAnimator.animateSwipeCalled).to(beTrue())
-          expect(mockAnimator.animateSwipeForced).to(equal(forced))
-          expect(mockAnimator.animateSwipeTopCard).to(equal(topCard))
-          expect(mockAnimator.animateSwipeDirection).to(equal(direction))
-        }
-      }
-    }
-
-    // MARK: - Did Reverse Swipe
-
-    describe("When the calling didReverseSwipe") {
       beforeEach {
-        subject.card(didReverseSwipe: SwipeCard(), from: .left)
+        subject.card(didSwipe: SwipeCard(), with: direction)
       }
 
-      it("should disable user interaction on the card") {
-        expect(subject.isUserInteractionEnabled).to(beFalse())
-      }
-
-      it("should call the animator's undo method") {
-        expect(mockAnimator.animateUndoCalled).to(beTrue())
+      it("and should call swipeAction with the correct parameters") {
+        expect(subject.swipeActionCalled).to(beTrue())
+        expect(subject.swipeActionDirection).to(equal(direction))
+        expect(subject.swipeActionForced).to(beFalse())
+        expect(subject.swipeActionAnimated).to(beTrue())
       }
     }
 

--- a/Tests/ShuffleTests/SwipeCardStack/Testables/TestableSwipeCardStack.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Testables/TestableSwipeCardStack.swift
@@ -50,22 +50,28 @@ class TestableSwipeCardStack: SwipeCardStack {
 
   // MARK: - Completion Blocks
 
-  var swipeCompletionCalled: Bool = false
+  var swipeCompletionBlockCalled: Bool = false
+  var testSwipeCompletionBlock: (() -> Void)?
+
   override var swipeCompletionBlock: () -> Void {
-    swipeCompletionCalled = true
-    return super.swipeCompletionBlock
+    swipeCompletionBlockCalled = true
+    return testSwipeCompletionBlock ?? super.swipeCompletionBlock
   }
 
-  var undoCompletionCalled: Bool = false
+  var undoCompletionBlockCalled: Bool = false
+  var testUndoCompletionBlock: (() -> Void)?
+
   override var undoCompletionBlock: () -> Void {
-    undoCompletionCalled = true
-    return super.undoCompletionBlock
+    undoCompletionBlockCalled = true
+    return testUndoCompletionBlock ?? super.undoCompletionBlock
   }
 
-  var shiftCompletionCalled: Bool = false
+  var shiftCompletionBlockCalled: Bool = false
+  var testShiftCompletionBlock: (() -> Void)?
+
   override var shiftCompletionBlock: () -> Void {
-    shiftCompletionCalled = true
-    return super.shiftCompletionBlock
+    shiftCompletionBlockCalled = true
+    return testShiftCompletionBlock ?? super.shiftCompletionBlock
   }
 
   // MARK: - Lifecycle
@@ -85,6 +91,25 @@ class TestableSwipeCardStack: SwipeCardStack {
     layoutCardCalled = true
     layoutCardCards.append(card)
     layoutCardIndices.append(index)
+  }
+
+  var swipeActionCalled = false
+  var swipeActionDirection: SwipeDirection?
+  var swipeActionForced: Bool?
+  var swipeActionAnimated: Bool?
+
+  override func swipeAction(topCard: SwipeCard,
+                            direction: SwipeDirection,
+                            forced: Bool,
+                            animated: Bool) {
+    swipeActionCalled = true
+    swipeActionDirection = direction
+    swipeActionForced = forced
+    swipeActionAnimated = animated
+    super.swipeAction(topCard: topCard,
+                      direction: direction,
+                      forced: forced,
+                      animated: animated)
   }
 
   var testLoadCard: SwipeCard?


### PR DESCRIPTION
- Fix issue where the background cards would still animate if any of the main `SwipeCardStack` stacks were called with `animated = false`
- Update tests
- Remove some internal `SwipeCardDelegate` methods to reserve these only for interaction-based events (i.e. don't call `didSwipe` on a programmatic swipe, remove `didReverseSwipe`)