### PR TITLE
replace shouldRecognizeDrag delegate methods with variables

### DIFF
--- a/Sources/Shuffle/SwipeCard/SwipeCard.swift
+++ b/Sources/Shuffle/SwipeCard/SwipeCard.swift
@@ -29,7 +29,7 @@ let CardDidFinishSwipeAnimationNotification = NSNotification.Name(rawValue: "car
 
 open class SwipeCard: SwipeView {
 
-  public var animationOptions: CardAnimatableOptions = CardAnimationOptions.default
+  open var animationOptions: CardAnimatableOptions = CardAnimationOptions.default
 
   /// The the main content view.
   public var content: UIView? {
@@ -88,7 +88,7 @@ open class SwipeCard: SwipeView {
 
   // MARK: - Initialization
 
-   override public init(frame: CGRect) {
+  override public init(frame: CGRect) {
     super.init(frame: frame)
     initialize()
   }
@@ -172,26 +172,6 @@ open class SwipeCard: SwipeView {
     super.didCancelSwipe(recognizer)
     delegate?.card(didCancelSwipe: self)
     animator.animateReset(on: self)
-  }
-
-  override open func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-    if gestureRecognizer != panGestureRecognizer {
-      return super.gestureRecognizerShouldBegin(gestureRecognizer)
-    }
-
-    let velocity = panGestureRecognizer.velocity(in: superview)
-
-    if let shouldRecognizeHorizontalDrag = delegate?.shouldRecognizeHorizontalDrag(on: self),
-      abs(velocity.x) > abs(velocity.y) {
-      return shouldRecognizeHorizontalDrag
-    }
-
-    if let shouldRecognizeVerticalDrag = delegate?.shouldRecognizeVerticalDrag(on: self),
-      abs(velocity.x) < abs(velocity.y) {
-      return shouldRecognizeVerticalDrag
-    }
-
-    return super.gestureRecognizerShouldBegin(gestureRecognizer)
   }
 
   // MARK: - Main Methods

--- a/Sources/Shuffle/SwipeCard/SwipeCardDelegate.swift
+++ b/Sources/Shuffle/SwipeCard/SwipeCardDelegate.swift
@@ -30,7 +30,4 @@ protocol SwipeCardDelegate: AnyObject {
   func card(didContinueSwipe card: SwipeCard)
   func card(didSwipe card: SwipeCard, with direction: SwipeDirection)
   func card(didTap card: SwipeCard)
-
-  func shouldRecognizeHorizontalDrag(on card: SwipeCard) -> Bool?
-  func shouldRecognizeVerticalDrag(on card: SwipeCard) -> Bool?
 }

--- a/Sources/Shuffle/SwipeCardStack/SwipeCardStackDelegate.swift
+++ b/Sources/Shuffle/SwipeCardStack/SwipeCardStackDelegate.swift
@@ -37,18 +37,4 @@ import Foundation
 
   @objc
   optional func didSwipeAllCards(_ cardStack: SwipeCardStack)
-
-  /// Implement this method and return `false` if you wish to ignore all horizontal gestures on the card stack.
-  ///
-  /// You may wish to implement this method if your card stack is embedded in a `UIScrollView`.
-  /// - Parameter cardStack: The card stack.
-  @objc
-  optional func shouldRecognizeHorizontalDrag(on cardStack: SwipeCardStack) -> Bool
-
-  /// Implement this method and return `false` if you wish to ignore all vertical gestures on the card stack.
-  ///
-  /// You may wish to implement this method if your card stack is embedded in a `UIScrollView`.
-  /// - Parameter cardStack: The card stack.
-  @objc
-  optional func shouldRecognizeVerticalDrag(on cardStack: SwipeCardStack) -> Bool
 }

--- a/Tests/ShuffleTests/SwipeCard/Specs/SwipeCardSpec_Base.swift
+++ b/Tests/ShuffleTests/SwipeCard/Specs/SwipeCardSpec_Base.swift
@@ -355,60 +355,6 @@ class SwipeCardSpec_Base: QuickSpec {
         expect(mockCardAnimator.animateResetCalled) == true
       }
     }
-
-    // MARK: Gesture Recognizer Should Begin
-
-    describe("When calling gestureRecognizerShouldBegin") {
-      context("and the gesture recognizer is not the card's panGestureRecognizer") {
-        it("should return the value from the superclass") {
-          let actualResult = subject.gestureRecognizerShouldBegin(UIGestureRecognizer())
-          expect(actualResult) == true
-        }
-      }
-
-      context("and the swipe is horizontal") {
-        let recognizeHorizontalDrag: Bool = false
-
-        beforeEach {
-          mockSwipeCardDelegate.testShouldRecognizeHorizontalDrag = recognizeHorizontalDrag
-          testPanGestureRecognizer.performPan(withLocation: nil,
-                                              translation: nil,
-                                              velocity: CGPoint(x: 1, y: 0))
-        }
-
-        it("should return the value from the delegate") {
-          let actualResult = subject.gestureRecognizerShouldBegin(testPanGestureRecognizer)
-          expect(actualResult) == recognizeHorizontalDrag
-        }
-      }
-
-      context("and the swipe is vertical") {
-        let recognizeVerticalDrag: Bool = false
-
-        beforeEach {
-          mockSwipeCardDelegate.testShouldRecognizeVerticalDrag = recognizeVerticalDrag
-          testPanGestureRecognizer.performPan(withLocation: nil,
-                                              translation: nil,
-                                              velocity: CGPoint(x: 0, y: 1))
-        }
-
-        it("should return the value from the delegate") {
-          let actualResult = subject.gestureRecognizerShouldBegin(testPanGestureRecognizer)
-          expect(actualResult) == recognizeVerticalDrag
-        }
-      }
-
-      context("and the delegate is nil or the shouldDrag method has not been implemented") {
-        beforeEach {
-          subject.delegate = nil
-        }
-
-        it("should return the value from the superclass") {
-          let actualResult = subject.gestureRecognizerShouldBegin(testPanGestureRecognizer)
-          expect(actualResult) == true
-        }
-      }
-    }
   }
 }
 // swiftlint:enable closure_body_length function_body_length implicitly_unwrapped_optional

--- a/Tests/ShuffleTests/SwipeCardStack/Mocks/MockSwipeCardStackDelegate.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Mocks/MockSwipeCardStackDelegate.swift
@@ -63,14 +63,4 @@ class MockSwipeCardStackDelegate: SwipeCardStackDelegate {
   func didSwipeAllCards(_ cardStack: SwipeCardStack) {
     didSwipeAllCardsCalled = true
   }
-
-  var testShouldRecognizeHorizontalDrag = true
-  func shouldRecognizeHorizontalDrag(on cardStack: SwipeCardStack) -> Bool {
-    return testShouldRecognizeHorizontalDrag
-  }
-
-  var testShouldRecognizeVerticalDrag = true
-  func shouldRecognizeVerticalDrag(on cardStack: SwipeCardStack) -> Bool {
-    return testShouldRecognizeVerticalDrag
-  }
 }

--- a/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_Base.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_Base.swift
@@ -74,7 +74,7 @@ class SwipeCardStackSpec_Base: QuickSpec {
 
       func testDefaultProperties() {
         expect(cardStack.numberOfVisibleCards) == 2
-        expect(cardStack.animationOptions).to(be(CardStackAnimationOptions.default))
+        expect(cardStack.animationOptions) === CardStackAnimationOptions.default
 
         let expectedInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
         expect(cardStack.cardStackInsets) == expectedInsets
@@ -82,6 +82,9 @@ class SwipeCardStackSpec_Base: QuickSpec {
         expect(cardStack.delegate).to(beNil())
         expect(cardStack.dataSource).to(beNil())
         expect(cardStack.topCardIndex).to(beNil())
+
+        expect(cardStack.shouldRecognizeHorizontalDrag) == true
+        expect(cardStack.shouldRecognizeVerticalDrag) == true
 
         expect(cardStack.topCard).to(beNil())
         expect(cardStack.visibleCards) == []
@@ -98,18 +101,6 @@ class SwipeCardStackSpec_Base: QuickSpec {
     describe("When setting dataSource") {
       beforeEach {
         subject.dataSource = nil
-      }
-
-      it("should call reloadData") {
-        expect(subject.reloadDataCalled) == true
-      }
-    }
-
-    // MARK: Number Of Visible Cards
-
-    describe("When setting numberOfVisibleCards") {
-      beforeEach {
-        subject.numberOfVisibleCards = 0
       }
 
       it("should call reloadData") {
@@ -392,6 +383,72 @@ class SwipeCardStackSpec_Base: QuickSpec {
         let expectedTransform = CGAffineTransform(scaleX: scaleFactor.x,
                                                   y: scaleFactor.y)
         expect(actualTransform) == expectedTransform
+      }
+    }
+
+    // MARK: Gesture Recognizer Should Begin
+
+    describe("When calling gestureRecognizerShouldBegin") {
+      context("and the gesture recognizer is not the top card's panGestureRecognizer") {
+        it("should return the value from the card stack's superclass") {
+          let actualResult = subject.gestureRecognizerShouldBegin(UIGestureRecognizer())
+          expect(actualResult) == true
+        }
+      }
+
+      context("and the gesture recognizer is the top card's pan gesture recognizer") {
+        let topCard = SwipeCard()
+        var topCardPanGestureRecognizer: PanGestureRecognizer!
+
+        beforeEach {
+          subject.testTopCard = topCard
+          topCardPanGestureRecognizer = topCard.panGestureRecognizer as? PanGestureRecognizer
+        }
+
+        context("and the drag is horizontal") {
+          let shouldRecognizeHorizontalDrag: Bool = false
+
+          beforeEach {
+            subject.shouldRecognizeHorizontalDrag = shouldRecognizeHorizontalDrag
+            topCardPanGestureRecognizer.performPan(withLocation: nil,
+                                                   translation: nil,
+                                                   velocity: CGPoint(x: 1, y: 0))
+          }
+
+          it("should return recognizeHorizontalDrag") {
+            let actualResult = subject.gestureRecognizerShouldBegin(topCardPanGestureRecognizer)
+            expect(actualResult) == shouldRecognizeHorizontalDrag
+          }
+        }
+
+        context("and the drag is vertical") {
+          let shouldRecognizeVerticalDrag: Bool = false
+
+          beforeEach {
+            subject.shouldRecognizeVerticalDrag = shouldRecognizeVerticalDrag
+            topCardPanGestureRecognizer.performPan(withLocation: nil,
+                                                   translation: nil,
+                                                   velocity: CGPoint(x: 0, y: 1))
+          }
+
+          it("should return recognizeHorizontalDrag") {
+            let actualResult = subject.gestureRecognizerShouldBegin(topCardPanGestureRecognizer)
+            expect(actualResult) == shouldRecognizeVerticalDrag
+          }
+        }
+
+        context("and the drag has no direction") {
+          beforeEach {
+            topCardPanGestureRecognizer.performPan(withLocation: nil,
+                                                   translation: nil,
+                                                   velocity: CGPoint(x: 0, y: 0))
+          }
+
+          it("should return the value from the card's superclass") {
+            let actualResult = subject.gestureRecognizerShouldBegin(topCardPanGestureRecognizer)
+            expect(actualResult) == true
+          }
+        }
       }
     }
   }

--- a/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_SwipeCardDelegate.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_SwipeCardDelegate.swift
@@ -139,64 +139,6 @@ class SwipeCardStackSpec_SwipeCardDelegate: QuickSpec {
         expect(subject.swipeActionAnimated) == true
       }
     }
-
-    // MARK: - Should Recognize Horizontal Drag
-
-    describe("When the calling shouldRecognizeHorizontalDrag") {
-      context("and the delegate is nil or the delegate method has not been implemented") {
-        beforeEach {
-          subject.delegate = nil
-        }
-
-        it("should return nil") {
-          let actualResult = subject.shouldRecognizeHorizontalDrag(on: SwipeCard())
-          expect(actualResult).to(beNil())
-        }
-      }
-
-      context("and the delegate is not nil") {
-        let shouldRecognizeDrag = false
-
-        beforeEach {
-          mockDelegate.testShouldRecognizeHorizontalDrag = shouldRecognizeDrag
-          subject.delegate = mockDelegate
-        }
-
-        it("should return the value from the delegate") {
-          let actualResult = subject.shouldRecognizeHorizontalDrag(on: SwipeCard())
-          expect(actualResult) == shouldRecognizeDrag
-        }
-      }
-    }
-
-    // MARK: - Should Recognize Vertical Drag
-
-    describe("When the calling shouldRecognizeVerticalDrag") {
-      context("and the delegate is nil or the delegate method has not been implemented") {
-        beforeEach {
-          subject.delegate = nil
-        }
-
-        it("should return nil") {
-          let actualResult = subject.shouldRecognizeVerticalDrag(on: SwipeCard())
-          expect(actualResult).to(beNil())
-        }
-      }
-
-      context("and the delegate is not nil") {
-        let shouldRecognizeDrag = false
-
-        beforeEach {
-          mockDelegate.testShouldRecognizeVerticalDrag = shouldRecognizeDrag
-          subject.delegate = mockDelegate
-        }
-
-        it("should return the value from the delegate") {
-          let actualResult = subject.shouldRecognizeVerticalDrag(on: SwipeCard())
-          expect(actualResult) == shouldRecognizeDrag
-        }
-      }
-    }
   }
 }
 // swiftlint:enable function_body_length implicitly_unwrapped_optional


### PR DESCRIPTION
- Make `SwipeCardStack.animationOptions` `open` instead of `public`
- Make `SwipeCardStack.numberOfVisibleCards` `internal`. The reason for doing this is because right now there is no visible effect from changing it to anything other than the default `2`. Will make this `public` again if there is ever a change to the visual card stack layout
-  Simplify solution to #64 by replacing all delegate methods with `shouldRecognizeHorizontalDrag/shouldRecognizeVerticalDrag` on `SwipeCardStack`