### PR TITLE
fix bug where swipe delegate was called too early

### DIFF
--- a/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_Base.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_Base.swift
@@ -189,10 +189,10 @@ class SwipeCardStackSpec_Base: QuickSpec {
 
     // MARK: Is Enabled
 
-    for isUserInteractionEnabled in [false, true] {
+    for isAnimating in [false, true] {
       describe("When getting isEnabled") {
         beforeEach {
-          subject.isUserInteractionEnabled = isUserInteractionEnabled
+          subject.isAnimating = isAnimating
         }
 
         context("and there is no top card") {
@@ -200,8 +200,8 @@ class SwipeCardStackSpec_Base: QuickSpec {
             subject.testTopCard = nil
           }
 
-          it("should return isUserInteractionEnabled") {
-            expect(subject.isEnabled) == isUserInteractionEnabled
+          it("should return !isAnimating") {
+            expect(subject.isEnabled) == !isAnimating
           }
         }
 
@@ -227,50 +227,11 @@ class SwipeCardStackSpec_Base: QuickSpec {
               topCard.isUserInteractionEnabled = true
             }
 
-            it("should return isUserInteractionEnabled") {
-              expect(subject.isEnabled) == isUserInteractionEnabled
+            it("should return !isAnimating") {
+              expect(subject.isEnabled) == !isAnimating
             }
           }
         }
-      }
-    }
-
-    // MARK: Swipe Completion Block
-
-    describe("When the swipe completion block is called") {
-      beforeEach {
-        subject.isUserInteractionEnabled = false
-        subject.swipeCompletionBlock()
-      }
-
-      it("should enable user interaction on the card stack") {
-        expect(subject.isUserInteractionEnabled) == true
-      }
-    }
-
-    // MARK: Undo Completion Block
-
-    describe("When the undo completion block is called") {
-      beforeEach {
-        subject.isUserInteractionEnabled = false
-        subject.undoCompletionBlock()
-      }
-
-      it("should enable user interaction on the card stack") {
-        expect(subject.isUserInteractionEnabled) == true
-      }
-    }
-
-    // MARK: Shift Completion Block
-
-    describe("When the shift completion block is called") {
-      beforeEach {
-        subject.isUserInteractionEnabled = false
-        subject.shiftCompletionBlock()
-      }
-
-      it("should enable user interaction on the card stack") {
-        expect(subject.isUserInteractionEnabled) == true
       }
     }
 

--- a/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_MainMethods.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Specs/SwipeCardStackSpec_MainMethods.swift
@@ -28,7 +28,6 @@ import Quick
 import UIKit
 
 // swiftlint:disable closure_body_length implicitly_unwrapped_optional
-// swiftlint:disable:next type_body_length
 class SwipeCardStackSpec_MainMethods: QuickSpec {
 
   // swiftlint:disable:next function_body_length
@@ -138,7 +137,6 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
 
           beforeEach {
             mockStateManager.remainingIndices = remainingIndices
-            subject.testSwipeCompletionBlock = {}
             subject.visibleCards = [topCard, SwipeCard()]
             subject.testLoadCard = testLoadCard
             subject.swipeAction(topCard: topCard,
@@ -168,7 +166,6 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
         context("and there are no more cards to load") {
           beforeEach {
             mockStateManager.remainingIndices = [1, 2]
-            subject.testSwipeCompletionBlock = {}
             subject.visibleCards = [topCard, SwipeCard(), SwipeCard()]
             subject.swipeAction(topCard: topCard,
                                 direction: direction,
@@ -190,7 +187,6 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
         context("and there are no more cards to swipe") {
           beforeEach {
             mockStateManager.remainingIndices = []
-            subject.testSwipeCompletionBlock = {}
             subject.visibleCards = [topCard]
             subject.swipeAction(topCard: topCard,
                                 direction: direction,
@@ -219,20 +215,12 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
             expect(subject.visibleCards.contains(topCard)) == false
           }
 
-          it("should disable user interaction") {
-            expect(subject.isUserInteractionEnabled) == false
-          }
-
           it("should call the animator's swipe method with the correct parameters") {
             expect(mockAnimator.animateSwipeCalled) == true
             expect(mockAnimator.animateSwipeTopCard) == topCard
             expect(mockAnimator.animateSwipeForced) == forced
             expect(mockAnimator.animateSwipeAnimated) == animated
             expect(mockAnimator.animateSwipeDirection) == direction
-          }
-
-          it("should call the swipeCompletionBlock once the animation has completed") {
-            expect(subject.swipeCompletionBlockCalled) == true
           }
         }
       }
@@ -282,12 +270,7 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
 
             beforeEach {
               mockStateManager.undoSwipeSwipe = Swipe(previousSwipeIndex, previousSwipeDirection)
-              subject.testUndoCompletionBlock = {}
               subject.undoLastSwipe(animated: animated)
-            }
-
-            it("should disable user interaction") {
-              expect(subject.isUserInteractionEnabled) == false
             }
 
             it("should call the reloadVisibleCards method") {
@@ -310,10 +293,6 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
               it("should call the reverseSwipe method on the new topCard with the correct parameters") {
                 expect(topCard.reverseSwipeCalled) == true
                 expect(topCard.reverseSwipeDirection) == previousSwipeDirection
-              }
-
-              it("should invoke the undoCompletionBlock once the animation has completed") {
-                expect(subject.undoCompletionBlockCalled) == true
               }
             }
           }
@@ -375,13 +354,8 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
 
           beforeEach {
             mockStateManager.remainingIndices = [1, 2, 3]
-            subject.testShiftCompletionBlock = {}
             subject.visibleCards = [SwipeCard(), SwipeCard()]
             subject.shift(withDistance: distance, animated: animated)
-          }
-
-          it("should disable user interaction") {
-            expect(subject.isUserInteractionEnabled) == false
           }
 
           it("should call the state manager's shift method with the correct distance") {
@@ -397,10 +371,6 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
             expect(mockAnimator.animateShiftCalled) == true
             expect(mockAnimator.animateShiftDistance) == distance
             expect(mockAnimator.animateShiftAnimated) == animated
-          }
-
-          it("should call the shiftCompletionBlock once the animation has completed") {
-            expect(subject.shiftCompletionBlockCalled) == true
           }
         }
       }
@@ -443,7 +413,7 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
           mockDataSource.testNumberOfCards = numberOfCards
 
           subject.dataSource = mockDataSource
-          subject.isUserInteractionEnabled = false
+          subject.isAnimating = true
           subject.reloadData()
         }
 
@@ -460,8 +430,8 @@ class SwipeCardStackSpec_MainMethods: QuickSpec {
           expect(subject.reloadVisibleCardsCalled) == true
         }
 
-        it("should enable user interaction on the card stack") {
-          expect(subject.isUserInteractionEnabled) == true
+        it("should set isAnimating to false") {
+          expect(subject.isAnimating) == false
         }
       }
     }

--- a/Tests/ShuffleTests/SwipeCardStack/Testables/TestableSwipeCardStack.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Testables/TestableSwipeCardStack.swift
@@ -48,32 +48,6 @@ class TestableSwipeCardStack: SwipeCardStack {
     return testIsEnabled ?? super.isEnabled
   }
 
-  // MARK: - Completion Blocks
-
-  var swipeCompletionBlockCalled: Bool = false
-  var testSwipeCompletionBlock: (() -> Void)?
-
-  override var swipeCompletionBlock: () -> Void {
-    swipeCompletionBlockCalled = true
-    return testSwipeCompletionBlock ?? super.swipeCompletionBlock
-  }
-
-  var undoCompletionBlockCalled: Bool = false
-  var testUndoCompletionBlock: (() -> Void)?
-
-  override var undoCompletionBlock: () -> Void {
-    undoCompletionBlockCalled = true
-    return testUndoCompletionBlock ?? super.undoCompletionBlock
-  }
-
-  var shiftCompletionBlockCalled: Bool = false
-  var testShiftCompletionBlock: (() -> Void)?
-
-  override var shiftCompletionBlock: () -> Void {
-    shiftCompletionBlockCalled = true
-    return testShiftCompletionBlock ?? super.shiftCompletionBlock
-  }
-
   // MARK: - Lifecycle
 
   var setNeedsLayoutCalled: Bool = false


### PR DESCRIPTION
- Also add `isAnimating` property instead of toggling user interaction on the card stack.

Fixes #71 