### PR TITLE
add card:ForIndexAt and position:ForCardAtIndex methods

### DIFF
--- a/Example/TinderExample/TinderViewController.swift
+++ b/Example/TinderExample/TinderViewController.swift
@@ -175,6 +175,8 @@ extension TinderViewController: ButtonStackViewDelegate, SwipeCardStackDataSourc
       cardStack.swipe(.up, animated: true)
     case 4:
       cardStack.swipe(.right, animated: true)
+    case 5:
+      cardStack.reloadData()
     default:
       break
     }

--- a/Shuffle-iOS.podspec
+++ b/Shuffle-iOS.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name         = "Shuffle-iOS"
-s.version      = "0.2.6"
+s.version      = "0.2.7"
 s.platform     = :ios, "9.0"
 s.summary      = "A multi-directional card swiping library inspired by Tinder"
 
@@ -13,7 +13,7 @@ s.homepage     = "https://github.com/mac-gallagher/Shuffle"
 s.documentation_url = "https://github.com/mac-gallagher/Shuffle/tree/master/README.md"
 s.license      = { :type => 'MIT', :file => 'LICENSE' }
 s.author       = { "Mac Gallagher" => "jmgallagher36@gmail.com" }
-s.source       = { :git => "https://github.com/mac-gallagher/Shuffle.git", :tag => "v0.2.6" }
+s.source       = { :git => "https://github.com/mac-gallagher/Shuffle.git", :tag => "v0.2.7" }
 
 s.swift_version = "5.0"
 s.source_files = "Sources/**/*.{h,swift}"

--- a/Sources/Shuffle/SwipeCardStack/CardStackAnimator.swift
+++ b/Sources/Shuffle/SwipeCardStack/CardStackAnimator.swift
@@ -72,16 +72,16 @@ class CardStackAnimator: CardStackAnimatable {
     removeAllCardAnimations(cardStack)
 
     if !animated {
-      for (index, card) in cardStack.visibleCards.enumerated() {
-        card.transform = cardStack.transform(forCardAtIndex: index)
+      for (position, value) in cardStack.visibleCards.enumerated() {
+        value.card.transform = cardStack.transform(forCardAtPosition: position)
       }
       completion?(true)
       return
     }
 
     // place background cards in old positions
-    for (index, card) in cardStack.visibleCards.enumerated() {
-      card.transform = cardStack.transform(forCardAtIndex: index + distance)
+    for (position, value) in cardStack.visibleCards.enumerated() {
+      value.card.transform = cardStack.transform(forCardAtPosition: position + distance)
     }
 
     // animate background cards to new positions
@@ -100,8 +100,8 @@ class CardStackAnimator: CardStackAnimatable {
     removeBackgroundCardAnimations(cardStack)
 
     if !animated {
-      for (index, card) in cardStack.visibleCards.enumerated() {
-        cardStack.layoutCard(card, at: index)
+      for (position, value) in cardStack.visibleCards.enumerated() {
+        cardStack.layoutCard(value.card, at: position)
       }
       completion?(true)
       return
@@ -135,16 +135,16 @@ class CardStackAnimator: CardStackAnimatable {
     removeBackgroundCardAnimations(cardStack)
 
     if !animated {
-      for (index, card) in cardStack.backgroundCards.enumerated() {
-        cardStack.layoutCard(card, at: index + 1)
+      for (position, card) in cardStack.backgroundCards.enumerated() {
+        cardStack.layoutCard(card, at: position + 1)
       }
       completion?(true)
       return
     }
 
     // place background cards in old positions
-    for (index, card) in cardStack.backgroundCards.enumerated() {
-      card.transform = cardStack.transform(forCardAtIndex: index)
+    for (position, card) in cardStack.backgroundCards.enumerated() {
+      card.transform = cardStack.transform(forCardAtPosition: position)
     }
 
     // animate background cards to new positions
@@ -159,37 +159,37 @@ class CardStackAnimator: CardStackAnimatable {
   }
 
   func removeAllCardAnimations(_ cardStack: SwipeCardStack) {
-    cardStack.visibleCards.forEach { $0.removeAllAnimations() }
+    cardStack.visibleCards.forEach { $0.card.removeAllAnimations() }
   }
 
   // MARK: - Animation Keyframes
 
   func addCancelSwipeAnimationKeyFrames(_ cardStack: SwipeCardStack) {
-    for (index, card) in cardStack.backgroundCards.enumerated() {
-      let transform = cardStack.transform(forCardAtIndex: index + 1)
+    for (position, card) in cardStack.backgroundCards.enumerated() {
+      let transform = cardStack.transform(forCardAtPosition: position + 1)
       Animator.addTransformKeyFrame(to: card, transform: transform)
     }
   }
 
   func addShiftAnimationKeyFrames(_ cardStack: SwipeCardStack) {
-    for (index, card) in cardStack.visibleCards.enumerated() {
-      let transform = cardStack.transform(forCardAtIndex: index)
-      Animator.addTransformKeyFrame(to: card, transform: transform)
+    for (position, value) in cardStack.visibleCards.enumerated() {
+      let transform = cardStack.transform(forCardAtPosition: position)
+      Animator.addTransformKeyFrame(to: value.card, transform: transform)
     }
   }
 
   func addSwipeAnimationKeyFrames(_ cardStack: SwipeCardStack) {
-    for (index, card) in cardStack.visibleCards.enumerated() {
+    for (position, value) in cardStack.visibleCards.enumerated() {
       Animator.addKeyFrame {
-        cardStack.layoutCard(card, at: index)
+        cardStack.layoutCard(value.card, at: position)
       }
     }
   }
 
   func addUndoAnimationKeyFrames(_ cardStack: SwipeCardStack) {
-    for (index, card) in cardStack.backgroundCards.enumerated() {
+    for (position, card) in cardStack.backgroundCards.enumerated() {
       Animator.addKeyFrame {
-        cardStack.layoutCard(card, at: index + 1)
+        cardStack.layoutCard(card, at: position + 1)
       }
     }
   }

--- a/Sources/Shuffle/SwipeCardStack/CardStackTransformProvider.swift
+++ b/Sources/Shuffle/SwipeCardStack/CardStackTransformProvider.swift
@@ -27,7 +27,7 @@ import UIKit
 protocol CardStackTransformProvidable {
   func backgroundCardDragTransform(for cardStack: SwipeCardStack,
                                    topCard: SwipeCard,
-                                   topCardIndex: Int) -> CGAffineTransform
+                                   currentPosition: Int) -> CGAffineTransform
   func backgroundCardTransformPercentage(for cardStack: SwipeCardStack, topCard: SwipeCard) -> CGFloat
 }
 
@@ -37,11 +37,11 @@ class CardStackTransformProvider: CardStackTransformProvidable {
 
   func backgroundCardDragTransform(for cardStack: SwipeCardStack,
                                    topCard: SwipeCard,
-                                   topCardIndex: Int) -> CGAffineTransform {
+                                   currentPosition: Int) -> CGAffineTransform {
     let percentage = backgroundCardTransformPercentage(for: cardStack, topCard: topCard)
 
-    let currentScale = cardStack.scaleFactor(forCardAtIndex: topCardIndex)
-    let nextScale = cardStack.scaleFactor(forCardAtIndex: topCardIndex - 1)
+    let currentScale = cardStack.scaleFactor(forCardAtPosition: currentPosition)
+    let nextScale = cardStack.scaleFactor(forCardAtPosition: currentPosition - 1)
 
     let scaleX = (1 - percentage) * currentScale.x + percentage * nextScale.x
     let scaleY = (1 - percentage) * currentScale.y + percentage * nextScale.y

--- a/Tests/ShuffleTests/SwipeCardStack/Mocks/MockCardStackTransformProvider.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Mocks/MockCardStackTransformProvider.swift
@@ -29,13 +29,13 @@ class MockCardStackTransformProvider: CardStackTransformProvidable {
 
   var testBackgroundCardDragTransform: CGAffineTransform = .identity
   var backgroundCardDragTransformCard: SwipeCard?
-  var backgroundCardDragTransformIndex: Int?
+  var backgroundCardDragTransformPosition: Int?
 
   func backgroundCardDragTransform(for cardStack: SwipeCardStack,
                                    topCard: SwipeCard,
-                                   topCardIndex: Int) -> CGAffineTransform {
+                                   currentPosition: Int) -> CGAffineTransform {
     backgroundCardDragTransformCard = topCard
-    backgroundCardDragTransformIndex = topCardIndex
+    backgroundCardDragTransformPosition = currentPosition
     return testBackgroundCardDragTransform
   }
 

--- a/Tests/ShuffleTests/SwipeCardStack/Testables/TestableSwipeCardStack.swift
+++ b/Tests/ShuffleTests/SwipeCardStack/Testables/TestableSwipeCardStack.swift
@@ -58,13 +58,13 @@ class TestableSwipeCardStack: SwipeCardStack {
 
   var layoutCardCalled: Bool = false
   var layoutCardCards: [SwipeCard] = []
-  var layoutCardIndices: [Int] = []
+  var layoutCardPositions: [Int] = []
 
-  override func layoutCard(_ card: SwipeCard, at index: Int) {
-    super.layoutCard(card, at: index)
+  override func layoutCard(_ card: SwipeCard, at position: Int) {
+    super.layoutCard(card, at: position)
     layoutCardCalled = true
     layoutCardCards.append(card)
-    layoutCardIndices.append(index)
+    layoutCardPositions.append(position)
   }
 
   var swipeActionCalled = false
@@ -98,13 +98,13 @@ class TestableSwipeCardStack: SwipeCardStack {
 
   var insertCardCalled: Bool = false
   var insertCardCard: SwipeCard?
-  var insertCardIndex: Int?
+  var insertCardPosition: Int?
 
-  override func insertCard(_ card: SwipeCard, at index: Int) {
-    super.insertCard(card, at: index)
+  override func insertCard(_ value: Card, at position: Int) {
+    super.insertCard(value, at: position)
     insertCardCalled = true
-    insertCardCard = card
-    insertCardIndex = index
+    insertCardCard = value.card
+    insertCardPosition = position
   }
 
   var reloadDataCalled: Bool = false
@@ -114,13 +114,13 @@ class TestableSwipeCardStack: SwipeCardStack {
   }
 
   var testScaleFactor: CGPoint?
-  override func scaleFactor(forCardAtIndex index: Int) -> CGPoint {
-    return testScaleFactor ?? super.scaleFactor(forCardAtIndex: index)
+  override func scaleFactor(forCardAtPosition position: Int) -> CGPoint {
+    return testScaleFactor ?? super.scaleFactor(forCardAtPosition: position)
   }
 
   var testTransformForCard: CGAffineTransform?
-  override func transform(forCardAtIndex index: Int) -> CGAffineTransform {
-    return testTransformForCard ?? super.transform(forCardAtIndex: index)
+  override func transform(forCardAtPosition position: Int) -> CGAffineTransform {
+    return testTransformForCard ?? super.transform(forCardAtPosition: position)
   }
 
   var reloadVisibleCardsCalled: Bool = false
@@ -137,6 +137,6 @@ class TestableSwipeCardStack: SwipeCardStack {
 
     layoutCardCalled = false
     layoutCardCards = []
-    layoutCardIndices = []
+    layoutCardPositions = []
   }
 }


### PR DESCRIPTION
- Modify language to better differentiate a card's `dataSource` index and its position in the card stack (previously, these were both just referred to as `index`).
- Add `card:ForIndexAt` and `position:ForCardAtIndex` methods with tests
- Modify `visibleCards` variable to also include a card's `dataSource` index

Closes #85