### PR TITLE
[Parker] Make scaleFactor and transform methods open for DeckKit styling

### DIFF
--- a/Sources/Shuffle/Classes/SwipeCardStack/SwipeCardStack.swift
+++ b/Sources/Shuffle/Classes/SwipeCardStack/SwipeCardStack.swift
@@ -132,11 +132,11 @@ open class SwipeCardStack: UIView, SwipeCardDelegate, UIGestureRecognizerDelegat
     card.isUserInteractionEnabled = position == 0
   }
 
-  func scaleFactor(forCardAtPosition position: Int) -> CGPoint {
+  open func scaleFactor(forCardAtPosition position: Int) -> CGPoint {
     return position == 0 ? CGPoint(x: 1, y: 1) : CGPoint(x: 0.95, y: 0.95)
   }
 
-  func transform(forCardAtPosition position: Int) -> CGAffineTransform {
+  open func transform(forCardAtPosition position: Int) -> CGAffineTransform {
     let cardScaleFactor = scaleFactor(forCardAtPosition: position)
     return CGAffineTransform(scaleX: cardScaleFactor.x, y: cardScaleFactor.y)
   }


### PR DESCRIPTION
- Changed func scaleFactor to open func scaleFactor (line 135)
- Changed func transform to open func transform (line 139)
- Allows subclasses to override card layout behavior for custom styling
- Enables DeckKit-inspired visual styling with custom scale and offset values

This modification maintains backward compatibility while enabling enhanced customization for card stack visual appearance.